### PR TITLE
Make build reproducible

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -350,9 +350,9 @@ class ProjectBuilder(object):
         # Fetch all c and cpp files from the subdirs to compile.
         for library_name in self._sub_library_names:
             for extension in ["*.c", "*.cpp"]:
-                self._source_files.extend(glob.glob(
+                self._source_files.extend(sorted(glob.glob(
                     os.path.join(self._libtsk_path, library_name, extension)
-                ))
+                )))
 
         ext_modules = [Extension("pytsk3", self._source_files,
                                  **self.extension_args)]


### PR DESCRIPTION
by sorting the input file list
to avoid random .o file link ordering
causing functions to be randomly ordered in the .so file

See https://reproducible-builds.org/ for why this is good.