### PR TITLE
Fixing broken hyperlink in README

### DIFF
--- a/README
+++ b/README
@@ -19,7 +19,8 @@ to make the binding reflect the TSK API as much as possible in
 capabilities, while at the same time having a nice Pythonic OO
 interface:
 
-http://www.sleuthkit.org/sleuthkit/docs/api-docs/index.html
+4.2: http://www.sleuthkit.org/sleuthkit/docs/api-docs/4.2/
+4.3: http://www.sleuthkit.org/sleuthkit/docs/api-docs/4.3/
 
 The new binding just links to libtsk which should make it easier to
 maintain against newer versions. We should be able to rewrite all the


### PR DESCRIPTION
Greetings--

[Line #22](https://github.com/py4n6/pytsk/blob/master/README#L22) of the current README for pytsk links to a non-existent page. I added two valid URL's for the 4.2 and 4.3 API documentation. Hope this helps.

--
Adam