### PR TITLE
Permit to read NTFS attributes data through read_random & list $Orphan files

### DIFF
--- a/tsk3.c
+++ b/tsk3.c
@@ -484,7 +484,7 @@ static uint64_t File_read_random(File self, TSK_OFF_T offset,
     RaiseError(EInvalidParameter, "id parameter is invalid.");
     return 0;
   };
-  if(id >= 0) {
+  if(id > 0) {
     result = tsk_fs_file_read_type(self->info, type, (uint16_t) id, offset, buff, len, flags);
   } else {
     result = tsk_fs_file_read(self->info, offset, buff, len, flags);

--- a/tsk3.c
+++ b/tsk3.c
@@ -484,7 +484,7 @@ static uint64_t File_read_random(File self, TSK_OFF_T offset,
     RaiseError(EInvalidParameter, "id parameter is invalid.");
     return 0;
   };
-  if(id > 0) {
+  if(id >= 0) {
     result = tsk_fs_file_read_type(self->info, type, (uint16_t) id, offset, buff, len, flags);
   } else {
     result = tsk_fs_file_read(self->info, offset, buff, len, flags);

--- a/tsk3.c
+++ b/tsk3.c
@@ -510,7 +510,11 @@ static Directory File_as_directory(File self) {
         RaiseError(EInvalidParameter, "Invalid parameter: self->info.");
         return NULL;
     }
+#if defined( TSK_VERSION_NUM ) && ( TSK_VERSION_NUM >= 0x040402ff )
     if(self->info->meta == NULL || !(TSK_FS_IS_DIR_META(self->info->meta->type))) {
+#else
+    if(self->info->meta == NULL || self->info->meta->type != TSK_FS_META_TYPE_DIR) {
+#endif
         RaiseError(EIOError, "Not a directory");
         return NULL;
     }

--- a/tsk3.c
+++ b/tsk3.c
@@ -510,7 +510,7 @@ static Directory File_as_directory(File self) {
         RaiseError(EInvalidParameter, "Invalid parameter: self->info.");
         return NULL;
     }
-    if(self->info->meta == NULL || self->info->meta->type != TSK_FS_META_TYPE_DIR) {
+    if(self->info->meta == NULL || !(TSK_FS_IS_DIR_META(self->info->meta->type))) {
         RaiseError(EIOError, "Not a directory");
         return NULL;
     }


### PR DESCRIPTION
Add the possibility to :
- list deleted files from the `$Orphans` pseudo directory (by being able to list files in the `$Orphans` dir)
- get data from NTFS attributes with an ID set to 0 (for instance some  $FILENAME or $STANDARD_INFO)

For the NTFS attributes, the `id` default value given to `read_random` is -1.
If it is not given, it is assumed that we want to read from the default attribute of the file ($DATA for NTFS, data stream for FAT...)
With this change, one can read data from other NTFS attributes and parse them