### PR TITLE
add parameter to setup.py update to use latest version from sleuthkit

### DIFF
--- a/README
+++ b/README
@@ -35,6 +35,10 @@ If downloaded pytsk using git you'll have to first run:
 
 python setup.py update
 
+If you want to use a bleeding edge version of sleuthkit, use the --bleedingedge parameter:
+
+python setup.py update --bleedingedge
+
 To build the bindings just use the standard Python distutils method:
 
 python setup.py build

--- a/setup.py
+++ b/setup.py
@@ -238,13 +238,15 @@ class UpdateCommand(Command):
   version_pkg = '%s %s' % (
       time.strftime('%a, %d %b %Y %H:%M:%S'), timezone_string)
 
-  user_options = []
+  user_options = [
+  ('bleedingedge', None, 'Use bleeding edge version of sleuthkit'),
+  ]
 
   def initialize_options(self):
-    pass
+    self.bleedingedge = False
 
   def finalize_options(self):
-    pass
+    self.bleedingedge = bool(self.bleedingedge)
 
   files = {
       "sleuthkit/configure.ac": [
@@ -302,11 +304,15 @@ class UpdateCommand(Command):
         ["git", "clean", "-x", "-f", "-d"], cwd="sleuthkit")
     subprocess.check_call(["git", "checkout", "master"], cwd="sleuthkit")
     subprocess.check_call(["git", "pull"], cwd="sleuthkit")
-    subprocess.check_call(["git", "fetch", "--tags"], cwd="sleuthkit")
-    subprocess.check_call(
+    if self.bleedingedge == False:
+      print('Pulling from tag 4.6.0')
+      subprocess.check_call(["git", "fetch", "--tags"], cwd="sleuthkit")
+      subprocess.check_call(
         ["git", "checkout", "tags/sleuthkit-4.6.0"], cwd="sleuthkit")
 
-    self.patch_sleuthkit()
+      self.patch_sleuthkit()
+    else:
+      print('Using latest/bleeding edge code')
 
     compiler_type = distutils.ccompiler.get_default_compiler()
     if compiler_type != "msvc":


### PR DESCRIPTION
Add the `--bleedingedge `parameter to use the latest commit from sleuthkit instead of using a fixed release

For instance, for people using python3 on windows and not needing VS 9.0 compatibility (needed for python 2.7), one can manually compile the extension using the latests commits/patches/bugfixes from sleuthkit.

This parameter is disabled by default to keep the current behavior of keeping VS 9.0 compatibility through the various patches made by J. Metz (thanks!)

For using this: 
`python(3) setup.py update --bleedingedge`