### PR TITLE
Changes to generation of pytsk3.c for reproducible build

### DIFF
--- a/class_parser.py
+++ b/class_parser.py
@@ -940,7 +940,8 @@ uint64_t integer_object_copy_to_uint64(PyObject *integer_object) {{
         for class_name in self.classes.keys():
             self.initialise_class(class_name, out, done)
 
-        # Add the constants in here
+        # Add the constants here. Make sure they are sorted so builds
+        # of pytsk3.c are reproducible.
         for constant, type in sorted(self.constants):
             if type == "integer":
                 out.write(

--- a/class_parser.py
+++ b/class_parser.py
@@ -941,7 +941,7 @@ uint64_t integer_object_copy_to_uint64(PyObject *integer_object) {{
             self.initialise_class(class_name, out, done)
 
         # Add the constants in here
-        for constant, type in self.constants:
+        for constant, type in sorted(self.constants):
             if type == "integer":
                 out.write(
                     "    tmp = PyLong_FromUnsignedLongLong((uint64_t) {0:s});\n".format(constant))


### PR DESCRIPTION
Whilst working on the [Reproducible Builds effort](https://reproducible-builds.org/) I noticed that pytsk could not be built reproducibly.

This is because it generated a pytsk3.c file in a nondeterministic manner, specifically by naively iterating over a Python set() structure.

(I originally filed this in Debian as bug [#992060](https://bugs.debian.org/992060).)