### PR TITLE
Added free-threaded Python 3.14 (3.14t) test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,8 @@ jobs:
         include:
         - python-version: '3.14'
           toxenv: 'py314'
+        - python-version: '3.14t'
+          toxenv: 'py314t'
     steps:
     - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
@@ -18,7 +20,12 @@ jobs:
     - name: Install build dependencies
       run: |
         brew update -q
-        brew install -q autoconf automake gettext gnu-sed libtool pkgconfig python@${{ matrix.python-version }} tox
+        brew install -q autoconf automake gettext gnu-sed libtool pkgconfig tox
+        # No brew formula for free-threaded; setup-python supplies 3.14t.
+        if [[ "${{ matrix.python-version }}" != *t ]]; then
+          brew install -q python@${{ matrix.python-version }}
+        fi
+        brew link --force gettext
         ln -s /usr/local/bin/glibtoolize /usr/local/bin/libtoolize
         python3 -m pip install setuptools
     - name: Build and test Python module
@@ -29,6 +36,7 @@ jobs:
   build_ubuntu:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         include:
         - python-version: '3.10'
@@ -41,17 +49,24 @@ jobs:
           toxenv: 'py313'
         - python-version: '3.14'
           toxenv: 'py314'
+        - python-version: '3.14t'
+          toxenv: 'py314t'
     steps:
     - uses: actions/checkout@v6
+    # deadsnakes ships python3.14-nogil without Python.h; setup-python includes headers.
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
     - name: Install build dependencies
       run: |
-        sudo add-apt-repository universe &&
-        sudo add-apt-repository -y ppa:deadsnakes/ppa &&
-        sudo apt-get update &&
-        sudo apt-get install -y autoconf automake autopoint autotools-dev build-essential git libtool pkg-config python${{ matrix.python-version }} python${{ matrix.python-version }}-dev python${{ matrix.python-version }}-venv python3-pip python3-setuptools
-    - name: Install tox
+        sudo apt-get update
+        sudo apt-get install -y autoconf automake autopoint \
+          autotools-dev build-essential git libtool pkg-config
+    # setup-python no longer bundles setuptools on 3.12+.
+    - name: Install Python build tooling
       run: |
-        python3 -m pip install tox
+        python -m pip install setuptools tox
     - name: Build and test Python module
       run: |
         python ./utils/update_source.py
@@ -60,7 +75,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: ['3.14']
+        python-version: ['3.14', '3.14t']
         architecture: ['x86', 'x64']
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,11 +21,10 @@ jobs:
       run: |
         brew update -q
         brew install -q autoconf automake gettext gnu-sed libtool pkgconfig tox
-        # No brew formula for free-threaded; setup-python supplies 3.14t.
+        # There currently is no brew formula for free-threaded Python, but setup-python will install it if necessary.
         if [[ "${{ matrix.python-version }}" != *t ]]; then
           brew install -q python@${{ matrix.python-version }}
         fi
-        brew link --force gettext
         ln -s /usr/local/bin/glibtoolize /usr/local/bin/libtoolize
         python3 -m pip install setuptools
     - name: Build and test Python module
@@ -55,18 +54,16 @@ jobs:
     - uses: actions/checkout@v6
     # deadsnakes ships python3.14-nogil without Python.h; setup-python includes headers.
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install build dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y autoconf automake autopoint \
-          autotools-dev build-essential git libtool pkg-config
-    # setup-python no longer bundles setuptools on 3.12+.
-    - name: Install Python build tooling
+        sudo apt-get install -y autoconf automake autopoint autotools-dev build-essential git libtool pkg-config
+    - name: Install tox
       run: |
-        python -m pip install setuptools tox
+        python -m pip install tox
     - name: Build and test Python module
       run: |
         python ./utils/update_source.py

--- a/aff4_errors.h
+++ b/aff4_errors.h
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #ifndef AFF4_ERRORS_H_
 #define AFF4_ERRORS_H_
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py3{10,11,12,13,14}
+envlist = py3{10,11,12,13,14,14t}
 
 [testenv]
 pip_pre = True


### PR DESCRIPTION
## Summary

Infrastructure-only change that adds Python 3.14 free-threaded (`3.14t`) to the CI matrix so subsequent free-threading work can actually be tested on CI.

This is the first in a planned series; it intentionally contains no runtime changes.

This is PR 1 of a planned 5-PR split of the `freethreading-compat-fixes` work.