### PR TITLE
Improved sanity checks in tsk3.cpp and class_parser.py with regression tests

### DIFF
--- a/class_parser.py
+++ b/class_parser.py
@@ -371,11 +371,6 @@ class Module:
  */
 static int TOTAL_CCLASSES=0;
 
-/* This is a global reference to this module so classes can call each
- * other.
- */
-static PyObject *g_module = NULL;
-
 #define CONSTRUCT_INITIALIZE(cclass, virt_cclass, constructor, object, ...) \\
     (cclass)(((virt_cclass) (&__ ## cclass))->constructor(object, ## __VA_ARGS__))
 
@@ -457,6 +452,9 @@ Gen_wrapper new_class_wrapper(Object item, int item_is_python_object) {{
                 PyErr_Clear();
 
                 result = (Gen_wrapper) _PyObject_New(python_wrapper->python_type);
+                if(result == NULL) {{
+                    return NULL;
+                }}
                 result->base = item;
                 result->base_is_python_object = item_is_python_object;
                 result->base_is_internal = 1;
@@ -561,10 +559,17 @@ static int check_method_override(PyObject *self, PyTypeObject *type, const char 
 #else
     py_method = PyString_FromString(method);
 #endif
+    if(py_method == NULL) {{
+        return 0;
+    }}
     number_of_items = PySequence_Size(mro);
 
     for(item_index = 0; item_index < number_of_items; item_index++) {{
+        int contains_result = 0;
         item_object = PySequence_GetItem(mro, item_index);
+        if(item_object == NULL) {{
+            break;
+        }}
 
         // Ok - we got to the base class - finish up
         if(item_object == (PyObject *) type) {{
@@ -576,8 +581,11 @@ static int check_method_override(PyObject *self, PyTypeObject *type, const char 
          * PyDict_Contains).
          */
         dict = PyObject_GetAttrString(item_object, "__dict__");
-        if(dict != NULL && PySequence_Contains(dict, py_method)) {{
-            found = 1;
+        if(dict != NULL) {{
+            contains_result = PySequence_Contains(dict, py_method);
+            if(contains_result > 0) {{
+                found = 1;
+            }}
         }}
         Py_DecRef(dict);
         Py_DecRef(item_object);
@@ -610,21 +618,58 @@ void pytsk_fetch_error(void) {{
     // Fetch the exception state and convert it to a string:
     PyErr_Fetch(&exception_type, &exception_value, &exception_traceback);
 
+    /* exception_value can be NULL when the original exception was
+     * raised via PyErr_SetNone(type) (e.g. KeyboardInterrupt).
+     */
+    if(exception_value == NULL) {{
+        if(error_str != NULL) {{
+            const char *placeholder = "Python exception raised without value";
+            size_t placeholder_len = strlen(placeholder);
+            if(placeholder_len > (size_t)(BUFF_SIZE - 1)) {{
+                placeholder_len = (size_t)(BUFF_SIZE - 1);
+            }}
+            memcpy(error_str, placeholder, placeholder_len);
+            error_str[placeholder_len] = 0;
+        }}
+        *error_type = ERuntimeError;
+        PyErr_Restore(exception_type, exception_value, exception_traceback);
+        return;
+    }}
+
     string_object = PyObject_Repr(exception_value);
 
 #if PY_MAJOR_VERSION >= 3
-    utf8_string_object = PyUnicode_AsUTF8String(string_object);
+    if(string_object != NULL) {{
+        utf8_string_object = PyUnicode_AsUTF8String(string_object);
+    }}
 
     if(utf8_string_object != NULL) {{
         str_c = PyBytes_AsString(utf8_string_object);
     }}
 #else
-    str_c = PyString_AsString(string_object);
+    if(string_object != NULL) {{
+        str_c = PyString_AsString(string_object);
+    }}
 #endif
 
     if(str_c != NULL) {{
         strncpy(error_str, str_c, BUFF_SIZE-1);
         error_str[BUFF_SIZE - 1] = 0;
+        *error_type = ERuntimeError;
+    }} else {{
+        /* Repr/encode failed; record a generic message so callers
+         * still observe ERuntimeError instead of EZero (which would
+         * make check_error() report success).
+         */
+        if(error_str != NULL) {{
+            const char *placeholder = "Python exception (repr failed)";
+            size_t placeholder_len = strlen(placeholder);
+            if(placeholder_len > (size_t)(BUFF_SIZE - 1)) {{
+                placeholder_len = (size_t)(BUFF_SIZE - 1);
+            }}
+            memcpy(error_str, placeholder, placeholder_len);
+            error_str[placeholder_len] = 0;
+        }}
         *error_type = ERuntimeError;
     }}
     PyErr_Restore(exception_type, exception_value, exception_traceback);
@@ -634,7 +679,9 @@ void pytsk_fetch_error(void) {{
         Py_DecRef(utf8_string_object);
     }}
 #endif
-    Py_DecRef(string_object);
+    if(string_object != NULL) {{
+        Py_DecRef(string_object);
+    }}
 
     return;
 }}
@@ -671,6 +718,18 @@ uint64_t integer_object_copy_to_uint64(PyObject *integer_object) {{
 #else
     long_value = PyLong_AsUnsignedLong(integer_object);
 #endif
+        /* PyLong_AsUnsignedLong / PyLong_AsUnsignedLongLong returns
+         * (unsigned)-1 and sets OverflowError when the value does
+         * not fit. Surfacing the original exception is more useful
+         * than continuing into the generic "out of bounds" path
+         * below, which would clobber the OverflowError with a fresh
+         * ValueError.
+         */
+        if(PyErr_Occurred()) {{
+            pytsk_fetch_error();
+
+            return (uint64_t) -1;
+        }}
     }}
 #if PY_MAJOR_VERSION < 3
     if(result == 0) {{
@@ -691,6 +750,11 @@ uint64_t integer_object_copy_to_uint64(PyObject *integer_object) {{
 #else
             long_value = PyInt_AsUnsignedLongMask(integer_object);
 #endif
+            if(PyErr_Occurred()) {{
+                pytsk_fetch_error();
+
+                return (uint64_t) -1;
+            }}
         }}
     }}
 #endif /* PY_MAJOR_VERSION < 3 */
@@ -767,8 +831,9 @@ uint64_t integer_object_copy_to_uint64(PyObject *integer_object) {{
                 "    if (PyType_Ready(&{name:s}_Type) < 0) {{\n"
                 "        goto on_error;\n"
                 "    }}\n"
-                "    Py_IncRef((PyObject *)&{name:s}_Type);\n"
-                "    PyModule_AddObject(module, \"{name:s}\", (PyObject *)&{name:s}_Type);\n").format(
+                "    if (PyModule_AddType(module, &{name:s}_Type) < 0) {{\n"
+                "        goto on_error;\n"
+                "    }}\n").format(
                     **values_dict))
 
     def write(self, out):
@@ -937,13 +1002,12 @@ uint64_t integer_object_copy_to_uint64(PyObject *integer_object) {{
             "\n"
             "    d = PyModule_GetDict(module);\n"
             "\n"
-            "    /* Make sure threads are enabled */\n"
-            "#if PY_VERSION_HEX < 0x03070000\n"
-            "    PyEval_InitThreads();\n"
-            "#endif\n"
             "    gil_state = PyGILState_Ensure();\n"
             "\n"
-            "    g_module = module;\n").format(**values_dict))
+            "    /* Reset class registry so reimport or subinterpreter import\n"
+            "     * repopulates from scratch and never overruns python_wrappers[].\n"
+            "     */\n"
+            "    TOTAL_CCLASSES = 0;\n").format(**values_dict))
 
         # The trick is to initialise the classes in order of their
         # inheritance. The following code will order initializations
@@ -1162,7 +1226,11 @@ class String(Type):
             "#endif\n"
             "        goto on_error;\n"
             "    }}\n"
-            "    {destination:s} = talloc_size({context:s}, length + 1);\n"
+            "    {destination:s} = (char *) talloc_size({context:s}, length + 1);\n"
+            "    if({destination:s} == NULL) {{\n"
+            "        PyErr_NoMemory();\n"
+            "        goto on_error;\n"
+            "    }}\n"
             "    memcpy({destination:s}, buff, length);\n"
             "    {destination:s}[length] = 0;\n"
             "}};\n").format(**values_dict)
@@ -1258,13 +1326,15 @@ class Integer(Type):
             "name": name or self.name,
             "result": result}
 
-        return (
+        code = (
             "    PyErr_Clear();\n"
-            "#if PY_MAJOR_VERSION >= 3\n"
-            "    {result:s} = PyLong_FromLong({name:s});\n"
-            "#else\n"
-            "    {result:s} = PyInt_FromLong({name:s});\n"
-            "#endif\n").format(**values_dict)
+            "    {result:s} = PyLong_FromLong({name:s});\n").format(**values_dict)
+        if kwargs.get('sense') == 'proxied':
+            code += (
+                "    if({result:s} == NULL) {{\n"
+                "        goto on_error;\n"
+                "    }}\n").format(**values_dict)
+        return code
 
     def from_python_object(self, source, destination, method, **kwargs):
         values_dict = {
@@ -1273,11 +1343,7 @@ class Integer(Type):
 
         return (
             "    PyErr_Clear();\n"
-            "#if PY_MAJOR_VERSION >= 3\n"
-            "    {destination:s} = PyLong_AsLongMask({source:s});\n"
-            "#else\n"
-            "    {destination:s} = PyInt_AsLongMask({source:s});\n"
-            "#endif\n").format(**values_dict)
+            "    {destination:s} = PyLong_AsLongMask({source:s});\n").format(**values_dict)
 
     def comment(self):
         return "{0:s} {1:s} ".format(self.original_type, self.name)
@@ -1309,13 +1375,15 @@ class IntegerUnsigned(Integer):
             values_dict = {
                 "name": name or self.name,
                 "result": result}
-            return (
+            code = (
                 "    PyErr_Clear();\n"
-                "#if PY_MAJOR_VERSION >= 3\n"
-                "    {result:s} = PyLong_FromLong((long) {name:s});\n"
-                "#else\n"
-                "    {result:s} = PyInt_FromLong((long) {name:s});\n"
-                "#endif\n").format(**values_dict)
+                "    {result:s} = PyLong_FromLong((long) {name:s});\n").format(**values_dict)
+            if kwargs.get('sense') == 'proxied':
+                code += (
+                    "    if({result:s} == NULL) {{\n"
+                    "        goto on_error;\n"
+                    "    }}\n").format(**values_dict)
+            return code
 
     def from_python_object(self, source, destination, method, **kwargs):
         values_dict = {
@@ -1364,13 +1432,19 @@ class Integer64(Integer):
             "name": name or self.name,
             "result": result}
 
-        return (
+        code = (
             "    PyErr_Clear();\n"
             "#if defined( HAVE_LONG_LONG )\n"
             "    {result:s} = PyLong_FromLongLong({name:s});\n"
             "#else\n"
             "    {result:s} = PyLong_FromLong({name:s});\n"
             "#endif\n").format(**values_dict)
+        if kwargs.get('sense') == 'proxied':
+            code += (
+                "    if({result:s} == NULL) {{\n"
+                "        goto on_error;\n"
+                "    }}\n").format(**values_dict)
+        return code
 
     def from_python_object(self, source, destination, method, **kwargs):
         values_dict = {
@@ -1403,13 +1477,19 @@ class Integer64Unsigned(Integer):
             "name": name or self.name,
             "result": result}
 
-        return (
+        code = (
             "    PyErr_Clear();\n"
             "#if defined( HAVE_LONG_LONG )\n"
             "    {result:s} = PyLong_FromUnsignedLongLong({name:s});\n"
             "#else\n"
             "    {result:s} = PyLong_FromUnsignedLong({name:s});\n"
             "#endif\n").format(**values_dict)
+        if kwargs.get('sense') == 'proxied':
+            code += (
+                "    if({result:s} == NULL) {{\n"
+                "        goto on_error;\n"
+                "    }}\n").format(**values_dict)
+        return code
 
     def from_python_object(self, source, destination, method, **kwargs):
         values_dict = {
@@ -1444,10 +1524,15 @@ class Long(Integer):
             "name": name or self.name,
             "result": result}
 
-        return (
+        code = (
             "PyErr_Clear();\n"
-            "{result:s} = PyLong_FromLongLong({name:s});\n").format(
-                **values_dict)
+            "{result:s} = PyLong_FromLongLong({name:s});\n").format(**values_dict)
+        if kwargs.get('sense') == 'proxied':
+            code += (
+                "if({result:s} == NULL) {{\n"
+                "    goto on_error;\n"
+                "}}\n").format(**values_dict)
+        return code
 
     def from_python_object(self, source, destination, method, **kwargs):
         values_dict = {
@@ -1469,10 +1554,15 @@ class LongUnsigned(Integer):
             "name": name or self.name,
             "result": result}
 
-        return (
+        code = (
             "PyErr_Clear();\n"
-            "{result:s} = PyLong_FromUnsignedLong({name:s});\n").format(
-                **values_dict)
+            "{result:s} = PyLong_FromUnsignedLong({name:s});\n").format(**values_dict)
+        if kwargs.get('sense') == 'proxied':
+            code += (
+                "if({result:s} == NULL) {{\n"
+                "    goto on_error;\n"
+                "}}\n").format(**values_dict)
+        return code
 
     def from_python_object(self, source, destination, method, **kwargs):
         values_dict = {
@@ -1650,8 +1740,11 @@ class Char_and_Length_OUT(Char_and_Length):
             kwargs["results"].pop(0)
 
         if sense == "proxied":
-            return "py_{0:s} = PyLong_FromLong({1:s});\n".format(
-                self.name, self.length)
+            return (
+                "py_{0:s} = PyLong_FromSize_t((size_t) {1:s});\n"
+                "if(py_{0:s} == NULL) {{\n"
+                "    goto on_error;\n"
+                "}}\n").format(self.name, self.length)
 
         values_dict = {
             "length": self.length,
@@ -1679,6 +1772,7 @@ class Char_and_Length_OUT(Char_and_Length):
 
     def python_proxy_post_call(self, result="Py_result"):
         values_dict = {
+            "length": self.length,
             "name": self.name,
             "result": result}
 
@@ -1694,9 +1788,20 @@ class Char_and_Length_OUT(Char_and_Length):
             "#endif\n"
             "        goto on_error;\n"
             "    }}\n"
+            "    /* Bound the user-controlled return length to the buffer\n"
+            "     * size that libtsk requested; a Python override that\n"
+            "     * returns more bytes than asked for would otherwise\n"
+            "     * overflow the caller's buffer.\n"
+            "     */\n"
+            "    if((size_t) tmp_len > (size_t) {length:s}) {{\n"
+            "        tmp_len = (Py_ssize_t) {length:s};\n"
+            "    }}\n"
             "    memcpy({name:s}, tmp_buff, tmp_len);\n"
             "    Py_DecRef({result:s});\n"
             "    {result:s} = PyLong_FromLong(tmp_len);\n"
+            "    if({result:s} == NULL) {{\n"
+            "        goto on_error;\n"
+            "    }}\n"
             "}}\n").format(**values_dict)
 
 
@@ -2132,6 +2237,9 @@ class StructWrapper(Wrapper):
             "        PyErr_Clear();\n"
             "\n"
             "        wrapped_{name:s} = (Gen_wrapper) PyObject_New(py{type:s}, &{type:s}_Type);\n"
+            "        if(wrapped_{name:s} == NULL) {{\n"
+            "            return NULL;\n"
+            "        }}\n"
             "\n").format(**values_dict)
 
         if borrowed:
@@ -2156,6 +2264,9 @@ class StructWrapper(Wrapper):
             result += (
                 "        if(wrapped_{name:s}->base == NULL) {{\n"
                 "             Py_DecRef((PyObject *) wrapped_{name:s});\n"
+                "             if(check_error()) {{\n"
+                "                 goto on_error;\n"
+                "             }}\n"
                 "             return NULL;\n"
                 "        }}\n").format(**values_dict)
 
@@ -2195,8 +2306,18 @@ class StructWrapper(Wrapper):
 
 class PointerStructWrapper(StructWrapper):
     def from_python_object(self, source, destination, method, **kwargs):
-        return "{0:s} = ({1:s} *) ((Gen_wrapper) {2:s})->base;\n".format(
-            destination, self.original_type, source)
+        values_dict = {
+            "destination": destination,
+            "source": source,
+            "type": self.original_type}
+        return (
+            "    if({source:s} == NULL || !type_check({source:s}, &{type:s}_Type)) {{\n"
+            "        PyErr_Format(PyExc_RuntimeError,\n"
+            "            \"proxied {type:s} method returned NULL or wrong type\");\n"
+            "        goto on_error;\n"
+            "    }}\n"
+            "    {destination:s} = ({type:s} *) ((Gen_wrapper) {source:s})->base;\n"
+        ).format(**values_dict)
 
     def byref(self):
         return "&wrapped_{0:s}".format(self.name)
@@ -2471,6 +2592,16 @@ class Method:
         if "DESTRUCTOR" in self.return_type.attributes:
             result += "self->base = NULL;\n"
 
+        # If a Python wrapper was already allocated but check_error() fired
+        # in the postcall, it must be released to avoid a refcount leak.
+        if isinstance(self.return_type,
+                      (StructWrapper, PointerStructWrapper, Wrapper, PointerWrapper)):
+            name = self.return_type.name
+            result += (
+                "    if(wrapped_{0:s} != NULL) {{\n"
+                "        Py_DecRef((PyObject *) wrapped_{0:s});\n"
+                "    }}\n").format(name)
+
         if hasattr(self, "args"):
             for type in self.args:
                 if hasattr(type, "error_cleanup"):
@@ -2736,6 +2867,10 @@ class SelfIteratorMethod(IteratorMethod):
 
         out.write((
             "{{\n"
+            "    if(self->base == NULL) {{\n"
+            "        return PyErr_Format(PyExc_RuntimeError,\n"
+            "            \"{class_name:s}.{method:s}: object is not bound to any libtsk handle\");\n"
+            "    }}\n"
             "    (({class_name:s}) self->base)->{method:s}(({class_name:s}) self->base);\n"
             "    return PyObject_SelfIter((PyObject *) self);\n"
             "}}\n").format(**values_dict))
@@ -2860,8 +2995,19 @@ class ConstructorMethod(Method):
 
         # Assign the initialise_proxies handler
         out.write((
-            "    self->python_object1 = NULL;\n"
-            "    self->python_object2 = NULL;\n"
+            "    /* Release any state from a prior __init__ call so that\n"
+            "     * re-initialization does not leak keepalives or libtsk handles.\n"
+            "     */\n"
+            "    Py_CLEAR(self->python_object1);\n"
+            "    Py_CLEAR(self->python_object2);\n"
+            "    if(self->base != NULL) {{\n"
+            "        if(self->base_is_python_object != 0) {{\n"
+            "            Py_DecRef((PyObject *) self->base);\n"
+            "        }} else if(self->base_is_internal != 0) {{\n"
+            "            talloc_free(self->base);\n"
+            "        }}\n"
+            "        self->base = NULL;\n"
+            "    }}\n"
             "\n"
             "    /* Initialise is used to keep a reference on the object?\n"
             "     * If not called no longer valid warnings have been seen\n"
@@ -2883,6 +3029,10 @@ class ConstructorMethod(Method):
             "\n"
             "    /* Allocate a new instance */\n"
             "    self->base = ({class_name:s}) alloc_{class_name:s}();\n"
+            "    if(self->base == NULL) {{\n"
+            "        PyErr_NoMemory();\n"
+            "        goto on_error;\n"
+            "    }}\n"
             "    self->base_is_python_object = 0;\n"
             "    self->base_is_internal = 1;\n"
             "    self->object_is_proxied = 0;\n"
@@ -3059,7 +3209,15 @@ class GetattrMethod(Method):
                 "#else\n"
                 "        string_object = PyString_FromString(\"{name:s}\");\n"
                 "#endif\n"
-                "        PyList_Append(list_object, string_object);\n"
+                "        if(string_object == NULL) {{\n"
+                "            Py_DecRef(list_object);\n"
+                "            goto on_error;\n"
+                "        }}\n"
+                "        if(PyList_Append(list_object, string_object) < 0) {{\n"
+                "            Py_DecRef(string_object);\n"
+                "            Py_DecRef(list_object);\n"
+                "            goto on_error;\n"
+                "        }}\n"
                 "        Py_DecRef(string_object);\n"
                 "\n").format(**values_dict))
 
@@ -3072,7 +3230,15 @@ class GetattrMethod(Method):
             "#else\n"
             "            string_object = PyString_FromString(i->ml_name);\n"
             "#endif\n"
-            "            PyList_Append(list_object, string_object);\n"
+            "            if(string_object == NULL) {{\n"
+            "                Py_DecRef(list_object);\n"
+            "                goto on_error;\n"
+            "            }}\n"
+            "            if(PyList_Append(list_object, string_object) < 0) {{\n"
+            "                Py_DecRef(string_object);\n"
+            "                Py_DecRef(list_object);\n"
+            "                goto on_error;\n"
+            "            }}\n"
             "            Py_DecRef(string_object);\n"
             "        }}\n"
             "#if PY_MAJOR_VERSION >= 3\n"
@@ -3176,6 +3342,13 @@ class GetattrMethod(Method):
                 "    PyObject *Py_result = NULL;\n"
                 "{python_def:s}\n"
                 "\n"
+                "    if(self->base == NULL) {{\n"
+                "        return PyErr_Format(PyExc_RuntimeError,\n"
+                "            \"{class_name:s}.{name:s}: object is not bound \"\n"
+                "            \"to any libtsk handle (was it instantiated \"\n"
+                "            \"directly?)\");\n"
+                "    }}\n"
+                "\n"
                 "{python_assign:s}\n"
                 "{python_obj:s}\n"
                 "\n"
@@ -3276,7 +3449,16 @@ class ProxiedMethod(Method):
             "    method_name = PyUnicode_FromString(\"{0:s}\");\n"
             "#else\n"
             "    method_name = PyString_FromString(\"{0:s}\");\n"
-            "#endif\n").format(self.name))
+            "#endif\n"
+            "    /* PyUnicode_FromString sets MemoryError on failure;\n"
+            "     * propagate via the proxied error machinery rather than\n"
+            "     * passing NULL to PyObject_CallMethodObjArgs (which would\n"
+            "     * raise SystemError and lose the original cause).\n"
+            "     */\n"
+            "    if(method_name == NULL) {{\n"
+            "        pytsk_fetch_error();\n"
+            "        goto on_error;\n"
+            "    }}\n").format(self.name))
 
         out.write("\n// Obtain Python objects for all the args:\n")
         for arg in self.args:
@@ -3293,7 +3475,6 @@ class ProxiedMethod(Method):
         out.write(
             "\n"
             "    // Now call the method\n"
-            "    PyErr_Clear();\n"
             "    Py_result = PyObject_CallMethodObjArgs((PyObject *) ((Object) self)->extension, method_name, ")
 
         for arg in self.args:
@@ -3322,12 +3503,27 @@ class ProxiedMethod(Method):
             "Py_result", self.return_type.name, self, context="self")
         out.write("    {0:s}".format(return_type))
 
-        out.write(
-            "    if(Py_result != NULL) {\n"
-            "        Py_DecRef(Py_result);\n"
-            "    }\n"
-            "    Py_DecRef(method_name);\n"
-            "\n")
+        # For Wrapper return types the Python wrapper keeps the C object alive.
+        # Transfer ownership to the parent's python_object2 so the C pointer
+        # remains valid after this callback returns to libtsk.
+        if isinstance(self.return_type, Wrapper) and not isinstance(
+                self.return_type, (StructWrapper, PointerStructWrapper)):
+            out.write(
+                "    if(Py_result != NULL) {\n"
+                "        PyObject *old = ((Gen_wrapper) ((Object) self)->extension)->python_object2;\n"
+                "        if(old != NULL) Py_DecRef(old);\n"
+                "        ((Gen_wrapper) ((Object) self)->extension)->python_object2 = Py_result;\n"
+                "        Py_result = NULL;\n"
+                "    }\n"
+                "    Py_DecRef(method_name);\n"
+                "\n")
+        else:
+            out.write(
+                "    if(Py_result != NULL) {\n"
+                "        Py_DecRef(Py_result);\n"
+                "    }\n"
+                "    Py_DecRef(method_name);\n"
+                "\n")
 
         # Decref all our Python objects:
         for arg in self.args:
@@ -3999,7 +4195,10 @@ class Enum(StructGenerator):
             "int {class_name:s}_init_type(\n"
             "    PyTypeObject *type_object )\n"
             "{{\n"
-            "    type_object->tp_dict = PyDict_New();\n").format(
+            "    type_object->tp_dict = PyDict_New();\n"
+            "    if(type_object->tp_dict == NULL) {{\n"
+            "        return 0;\n"
+            "    }}\n").format(
                 **values_dict))
 
         if self.values:
@@ -4010,11 +4209,23 @@ class Enum(StructGenerator):
                     "class_name": self.class_name,
                     "value": attr}
 
+                # Each enum value must succeed; otherwise the type's
+                # tp_dict is partially populated and the module loads
+                # with broken constants. Bail out cleanly so PyType_Ready
+                # never sees a half-initialized enum.
                 out.write((
                     "    integer_object = PyLong_FromLong({value:s});\n"
-                    "\n"
-                    "    PyDict_SetItemString(type_object->tp_dict, \"{value:s}\", integer_object);\n"
-                    "\n"
+                    "    if(integer_object == NULL) {{\n"
+                    "        Py_DecRef(type_object->tp_dict);\n"
+                    "        type_object->tp_dict = NULL;\n"
+                    "        return 0;\n"
+                    "    }}\n"
+                    "    if(PyDict_SetItemString(type_object->tp_dict, \"{value:s}\", integer_object) < 0) {{\n"
+                    "        Py_DecRef(integer_object);\n"
+                    "        Py_DecRef(type_object->tp_dict);\n"
+                    "        type_object->tp_dict = NULL;\n"
+                    "        return 0;\n"
+                    "    }}\n"
                     "    Py_DecRef(integer_object);\n"
                     "\n").format(**values_dict))
 

--- a/tests/security.py
+++ b/tests/security.py
@@ -1,0 +1,196 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+"""Security regression tests for pytsk3.
+
+Each test pins a previously-fixed vulnerability so that a future
+refactor cannot silently reintroduce it.
+"""
+
+import io
+import os
+import unittest
+
+import pytsk3
+
+
+_TEST_IMAGE = os.path.join('test_data', 'image.raw')
+
+
+class HeapOverflowOnProxiedReadTest(unittest.TestCase):
+  """Pin the bound on Python-supplied bytes from a subclass read().
+
+  ProxiedImg_Info_read used to memcpy(buf, tmp_buff, tmp_len) with no
+  upper bound on tmp_len, where tmp_len comes from the bytes object
+  the Python override returned. A subclass returning more bytes than
+  libtsk requested overflowed the libtsk-allocated heap buffer.
+
+  The codegen now clamps tmp_len to the requested length before the
+  copy. Returning oversized bytes must therefore be truncated rather
+  than corrupting heap memory.
+  """
+
+  def testOversizedSubclassReadIsClamped(self):
+    # The proxied callback path is only invoked when libtsk itself
+    # calls back into the Python subclass's read() (e.g. during
+    # FS_Info auto-detection). A direct `img.read(...)` from Python
+    # uses normal MRO and does not exercise the C memcpy. So the
+    # test feeds the real test image through a subclass whose read()
+    # is instrumented to return way more bytes than libtsk asks for;
+    # if the memcpy bound were missing, libtsk's cache slot would be
+    # corrupted and FS_Info would either crash or read garbage.
+    file_path = _TEST_IMAGE
+    file_size = os.stat(file_path).st_size
+    file_object = open(file_path, 'rb')
+    self.addCleanup(file_object.close)
+
+    class _OversizedSubclass(pytsk3.Img_Info):
+
+      def __init__(self):
+        self._file_object = file_object
+        self._file_size = file_size
+        self.max_overflow = 0
+        super().__init__(url='', type=pytsk3.TSK_IMG_TYPE_RAW)
+
+      def get_size(self):
+        return self._file_size
+
+      def read(self, offset, size):
+        self._file_object.seek(offset, os.SEEK_SET)
+        data = self._file_object.read(size)
+        # Return 4x what libtsk asked for. The C-side memcpy bound
+        # is what stops this from corrupting libtsk's cache slot.
+        # Track the largest overflow we attempted so the assertion
+        # below is meaningful even if libtsk asks for tiny sizes.
+        bloated = data + b'\xff' * len(data) * 3
+        self.max_overflow = max(self.max_overflow, len(bloated) - size)
+        return bloated
+
+    img = _OversizedSubclass()
+    try:
+      # FS_Info construction makes libtsk call img.read() multiple
+      # times to identify the filesystem. With the clamp in place
+      # this succeeds and returns valid file metadata. Without the
+      # clamp this either crashes or scrambles cache state, making
+      # the directory listing wrong / empty / corrupt.
+      fs = pytsk3.FS_Info(img, offset=0)
+      directory = fs.open_dir('/')
+      names = sorted(
+          entry.info.name.name
+          for entry in directory
+          if entry.info and entry.info.name)
+      # We deliberately returned oversized buffers from every read.
+      self.assertGreater(img.max_overflow, 0,
+                         'subclass never overflowed -- test inert')
+      # Listing must include the well-known fixture entries.
+      self.assertIn(b'passwords.txt', names)
+    finally:
+      img.close()
+
+
+class ExitMethodDoesNotKillInterpreterTest(unittest.TestCase):
+  """Pin the FS_Info.exit() denial-of-service fix.
+
+  FS_Info_exit used to call exit(0), letting any caller of
+  fs_info.exit() terminate the host Python interpreter. Now it must
+  raise a clean RuntimeError instead.
+  """
+
+  def testExitRaisesRuntimeError(self):
+    img = pytsk3.Img_Info(url=_TEST_IMAGE)
+    fs = pytsk3.FS_Info(img, offset=0)
+    with self.assertRaises(RuntimeError):
+      fs.exit()
+    # Process is still alive; reach into pytsk after exit() to prove
+    # we did not just survive in C-side limbo.
+    file_object = fs.open_meta(15)
+    self.assertEqual(file_object.info.meta.size, 116)
+
+
+class StructWrapperUninitializedAccessTest(unittest.TestCase):
+  """Pin the property-getter NULL-base guard.
+
+  Direct instantiation (e.g. `pytsk3.TSK_FS_BLOCK()`) leaves
+  self->base == NULL. Property access used to dereference NULL and
+  crash; it must now raise RuntimeError instead.
+  """
+
+  def _struct_classes(self):
+    candidates = [
+        'TSK_FS_BLOCK', 'TSK_FS_INFO', 'TSK_FS_NAME', 'TSK_FS_META',
+        'TSK_FS_FILE', 'TSK_FS_ATTR', 'TSK_FS_ATTR_RUN',
+        'TSK_VS_INFO', 'TSK_VS_PART_INFO',
+    ]
+    return [c for c in candidates if hasattr(pytsk3, c)]
+
+  def _candidate_attrs(self, class_name):
+    """Static list of property names per struct, so the test does not
+    have to call dir() on an unbound instance (dir() routes through
+    the wrapper's __getattr__ which itself trips the NULL-base
+    guard, before we get a chance to test individual properties).
+    """
+    return {
+        'TSK_FS_BLOCK': ('tag', 'fs_info', 'addr', 'flags'),
+        'TSK_FS_INFO': ('tag', 'block_count', 'block_size', 'inum_count'),
+        'TSK_FS_NAME': ('name', 'meta_addr', 'flags'),
+        'TSK_FS_META': ('addr', 'size', 'mode', 'type'),
+        'TSK_FS_FILE': ('tag', 'fs_info'),
+        'TSK_FS_ATTR': ('flags', 'name', 'type', 'id', 'size'),
+        'TSK_FS_ATTR_RUN': ('addr', 'len', 'offset', 'flags'),
+        'TSK_VS_INFO': ('tag', 'vstype', 'block_size', 'offset'),
+        'TSK_VS_PART_INFO': ('tag', 'addr', 'start', 'len', 'flags'),
+    }.get(class_name, ())
+
+  def testEveryStructWrapperRaisesOnUnboundAccess(self):
+    classes = self._struct_classes()
+    self.assertGreater(len(classes), 0, 'no struct wrappers found')
+    guard_hits = 0
+    for class_name in classes:
+      cls = getattr(pytsk3, class_name)
+      try:
+        instance = cls()
+      except TypeError:
+        # Some classes refuse direct construction; that's fine -- the
+        # vulnerability requires a NULL self->base reachable from
+        # Python, and refusing __init__ achieves the same end.
+        continue
+      for attr in self._candidate_attrs(class_name):
+        try:
+          getattr(instance, attr)
+        except RuntimeError:
+          # Raised by the NULL-base guard in the property getter
+          # prelude. This is the desired behavior.
+          guard_hits += 1
+        except (AttributeError, TypeError, IOError):
+          # Acceptable -- attribute does not exist on this build /
+          # version, or the wrapper's __getattr__ refused before
+          # reaching the property, both of which still avoid the
+          # crash this test is pinning.
+          pass
+    self.assertGreater(guard_hits, 0,
+                       'NULL-base guard was never exercised; test is inert')
+
+
+class ErrorMessageWithoutLibtskErrnoTest(unittest.TestCase):
+  """Pin the safe_tsk_error_get() helper.
+
+  RaiseError(..., "%s", tsk_error_get()) used to pass a NULL pointer
+  to %s when libtsk recorded no t_errno -- undefined behavior on
+  glibc. The wrapper now substitutes a placeholder string.
+  """
+
+  def testInvalidImageProducesUsableMessage(self):
+    # Hitting an internal libtsk error path that may not set t_errno
+    # ultimately raises through RaiseError; the resulting Python
+    # exception message must be a non-empty string with no NUL byte
+    # and no literal "(null)" leak from a NULL-on-%s formatter.
+    img = pytsk3.Img_Info(url=_TEST_IMAGE)
+    with self.assertRaises(IOError) as ctx:
+      pytsk3.FS_Info(img, offset=999_999_999_999)
+    message = str(ctx.exception)
+    self.assertTrue(message)
+    self.assertNotIn('\x00', message)
+    self.assertNotIn('(null)', message)
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/tsk3.cpp
+++ b/tsk3.cpp
@@ -37,6 +37,16 @@ extern void tsk_deinit_lock(tsk_lock_t * lock);
 ssize_t IMG_INFO_read(TSK_IMG_INFO *self, TSK_OFF_T off, char *buf, size_t len);
 void IMG_INFO_close(TSK_IMG_INFO *self);
 
+/* tsk_error_get() returns NULL when libtsk did not record a t_errno
+ * for the failure (some EOF / bounds paths return -1 without setting
+ * one). safe_tsk_error_get() guarantees a usable string. All call sites
+ * in pytsk pass through this wrapper.
+ */
+static const char *safe_tsk_error_get(void) {
+    const char *e = tsk_error_get();
+    return (e != NULL) ? e : "unknown libtsk error";
+}
+
 /* This macro is used to receive the object reference from a member of the type.
  */
 #define GET_Object_from_member(type, object, member) \
@@ -48,15 +58,22 @@ static int Img_Info_dest(Img_Info self) {
     if(self == NULL) {
         return -1;
     }
-    tsk_img_close((TSK_IMG_INFO *) self->img);
+    /* Guard against a partially-constructed Img_Info reaching the
+     * destructor before self->img was assigned (e.g. talloc_set_destructor
+     * is installed early so dest() runs on error-path return from
+     * Img_Info_Con before tsk_img_open succeeds).
+     */
+    if(self->img != NULL) {
+        tsk_img_close((TSK_IMG_INFO *) self->img);
 
-    if(self->img_is_internal != 0) {
+        if(self->img_is_internal != 0) {
 #if defined( TSK_MULTITHREAD_LIB )
-        tsk_deinit_lock(&(self->img->base.cache_lock));
+            tsk_deinit_lock(&(self->img->base.cache_lock));
 #endif
-        // If img is internal talloc will free it.
+            // If img is internal talloc will free it.
+        }
+        self->img = NULL;
     }
-    self->img = NULL;
 
     return 0;
 }
@@ -69,6 +86,14 @@ static Img_Info Img_Info_Con(Img_Info self, char *urn, TSK_IMG_TYPE_ENUM type) {
         RaiseError(EInvalidParameter, "Invalid parameter: self.");
         return NULL;
     }
+    /* Install the destructor before any allocation: tsk_img_open and
+     * talloc_zero below can fail and return NULL, in which case
+     * Img_Info_Con returns NULL and talloc still owns self. Without
+     * the destructor installed, talloc's free of self would skip
+     * Img_Info_dest and leak the partially-built img.
+     */
+    talloc_set_destructor((void *) self, (int(*)(void *)) &Img_Info_dest);
+
     if(urn != NULL && urn[0] != 0) {
 #ifdef TSK_VERSION_NUM
         self->img = (Extended_TSK_IMG_INFO *) tsk_img_open_utf8(1, (const char **) &urn, type, 0);
@@ -111,13 +136,11 @@ static Img_Info Img_Info_Con(Img_Info self, char *urn, TSK_IMG_TYPE_ENUM type) {
 #endif
     }
     if(self->img == NULL) {
-        RaiseError(EIOError, "Unable to open image: %s", tsk_error_get());
+        RaiseError(EIOError, "Unable to open image: %s", safe_tsk_error_get());
         tsk_error_reset();
         return NULL;
     }
     self->img_is_open = 1;
-
-    talloc_set_destructor((void *) self, (int(*)(void *)) &Img_Info_dest);
 
     return self;
 }
@@ -144,7 +167,7 @@ uint64_t Img_Info_read(Img_Info self, TSK_OFF_T off, OUT char *buf, size_t len) 
     read_count = CALL((TSK_IMG_INFO *) self->img, read, off, buf, len);
 
     if(read_count < 0) {
-        RaiseError(EIOError, "Unable to read image: %s", tsk_error_get());
+        RaiseError(EIOError, "Unable to read image: %s", safe_tsk_error_get());
         tsk_error_reset();
         return 0;
     }
@@ -196,7 +219,21 @@ ssize_t IMG_INFO_read(TSK_IMG_INFO *img, TSK_OFF_T off, char *buf, size_t len) {
     if(len == 0) {
       return 0;
     }
-    return (ssize_t) CALL(self->container, read, (uint64_t) off, buf, len);
+    /* The CALL macro suppresses any Python exception that the proxied
+     * subclass.read() may have raised. libtsk has no exception channel,
+     * so a Python error is invisible to it; the caller would receive
+     * whatever zero / garbage bytes the C return path produced. Check
+     * the pytsk error slot and report a hard failure so libtsk treats
+     * this as a read error rather than ambiguously short data.
+     */
+    {
+        uint64_t n = CALL(self->container, read, (uint64_t) off, buf, len);
+        char *unused_buf;
+        if(*aff4_get_current_error(&unused_buf) != EZero) {
+            return -1;
+        }
+        return (ssize_t) n;
+    }
 }
 
 /* FS_Info destructor
@@ -239,7 +276,7 @@ static FS_Info FS_Info_Con(FS_Info self, Img_Info img, TSK_OFF_T offset,
 
     if(!self->info) {
         RaiseError(EIOError, "Unable to open the image as a filesystem at offset: 0x%08" PRIxOFF " with error: %s",
-                   offset, tsk_error_get());
+                   offset, safe_tsk_error_get());
         tsk_error_reset();
         return NULL;
     }
@@ -289,21 +326,28 @@ static File FS_Info_open(FS_Info self, ZString path) {
     info = tsk_fs_file_open(self->info, NULL, path);
 
     if(info == NULL) {
-        RaiseError(EIOError, "Unable to open file: %s", tsk_error_get());
+        RaiseError(EIOError, "Unable to open file: %s", safe_tsk_error_get());
         tsk_error_reset();
         goto on_error;
     }
     // CONSTRUCT_CREATE calls _talloc_memdup to allocate memory for the object.
     object = CONSTRUCT_CREATE(File, File, NULL);
 
-    if(object != NULL) {
-        // CONSTRUCT_INITIALIZE calls the constructor function on the object.
-        if(CONSTRUCT_INITIALIZE(File, File, Con, object, self, info) == NULL) {
-            goto on_error;
-        }
-        // Tell the File object to manage info.
-        object->info_is_internal = 1;
+    /* Explicit ENoMemory raise: previously a NULL return silently fell
+     * through to "return object" (returning NULL) without setting an
+     * error, so the caller saw a SystemError "returned NULL without
+     * setting an exception" instead of a clean MemoryError.
+     */
+    if(object == NULL) {
+        RaiseError(ENoMemory, "Unable to allocate File.");
+        goto on_error;
     }
+    // CONSTRUCT_INITIALIZE calls the constructor function on the object.
+    if(CONSTRUCT_INITIALIZE(File, File, Con, object, self, info) == NULL) {
+        goto on_error;
+    }
+    // Tell the File object to manage info.
+    object->info_is_internal = 1;
     return object;
 
 on_error:
@@ -331,21 +375,23 @@ static File FS_Info_open_meta(FS_Info self, TSK_INUM_T inode) {
     info = tsk_fs_file_open_meta(self->info, NULL, inode);
 
     if(info == NULL) {
-        RaiseError(EIOError, "Unable to open file: %s", tsk_error_get());
+        RaiseError(EIOError, "Unable to open file: %s", safe_tsk_error_get());
         tsk_error_reset();
         goto on_error;
     }
     // CONSTRUCT_CREATE calls _talloc_memdup to allocate memory for the object.
     object = CONSTRUCT_CREATE(File, File, NULL);
 
-    if(object != NULL) {
-        // CONSTRUCT_INITIALIZE calls the constructor function on the object.
-        if(CONSTRUCT_INITIALIZE(File, File, Con, object, self, info) == NULL) {
-            goto on_error;
-        }
-        // Tell the File object to manage info.
-        object->info_is_internal = 1;
+    if(object == NULL) {
+        RaiseError(ENoMemory, "Unable to allocate File.");
+        goto on_error;
     }
+    // CONSTRUCT_INITIALIZE calls the constructor function on the object.
+    if(CONSTRUCT_INITIALIZE(File, File, Con, object, self, info) == NULL) {
+        goto on_error;
+    }
+    // Tell the File object to manage info.
+    object->info_is_internal = 1;
     return object;
 
 on_error:
@@ -360,7 +406,16 @@ on_error:
 
 static void FS_Info_exit(FS_Info self PYTSK3_ATTRIBUTE_UNUSED) {
   PYTSK3_UNREFERENCED_PARAMETER(self)
-  exit(0);
+  /* Previously called exit(0), which lets any Python caller of
+   * FS_Info.exit() kill the host interpreter -- a trivial denial of
+   * service for any process that loads pytsk3 alongside untrusted
+   * user code (notebooks, plugins, batch runners). Raise instead so
+   * the caller sees a clean RuntimeError.
+   */
+  RaiseError(ERuntimeError,
+             "FS_Info.exit is intentionally disabled; previously this "
+             "method called exit() from C and would terminate the host "
+             "interpreter.");
 };
 
 VIRTUAL(FS_Info, Object) {
@@ -405,7 +460,7 @@ static Directory Directory_Con(Directory self, FS_Info fs, ZString path, TSK_INU
         self->info = tsk_fs_dir_open(fs->info, path);
     }
     if(self->info == NULL) {
-        RaiseError(EIOError, "Unable to open directory: %s", tsk_error_get());
+        RaiseError(EIOError, "Unable to open directory: %s", safe_tsk_error_get());
         tsk_error_reset();
         return NULL;
     }
@@ -447,21 +502,23 @@ static File Directory_next(Directory self) {
     info = tsk_fs_dir_get(self->info, self->current);
 
     if(info == NULL) {
-        RaiseError(EIOError, "Error opening File: %s", tsk_error_get());
+        RaiseError(EIOError, "Error opening File: %s", safe_tsk_error_get());
         tsk_error_reset();
         goto on_error;
     }
     // CONSTRUCT_CREATE calls _talloc_memdup to allocate memory for the object.
     object = CONSTRUCT_CREATE(File, File, NULL);
 
-    if(object != NULL) {
-        // CONSTRUCT_INITIALIZE calls the constructor function on the object.
-        if(CONSTRUCT_INITIALIZE(File, File, Con, object, self->fs, info) == NULL) {
-            goto on_error;
-        }
-        // Tell the File object to manage info.
-        object->info_is_internal = 1;
+    if(object == NULL) {
+        RaiseError(ENoMemory, "Unable to allocate File.");
+        goto on_error;
     }
+    // CONSTRUCT_INITIALIZE calls the constructor function on the object.
+    if(CONSTRUCT_INITIALIZE(File, File, Con, object, self->fs, info) == NULL) {
+        goto on_error;
+    }
+    // Tell the File object to manage info.
+    object->info_is_internal = 1;
     self->current++;
 
     return object;
@@ -569,7 +626,7 @@ static uint64_t File_read_random(File self, TSK_OFF_T offset,
   };
 
   if(result < 0) {
-    RaiseError(EIOError, "Read error: %s", tsk_error_get());
+    RaiseError(EIOError, "Read error: %s", safe_tsk_error_get());
     tsk_error_reset();
     return 0;
   };
@@ -633,7 +690,7 @@ static Attribute File_iternext(File self) {
     attribute = (TSK_FS_ATTR *) tsk_fs_file_attr_get_idx(self->info, self->current_attr);
 
     if(!attribute)  {
-        RaiseError(EIOError, "Error opening File: %s", tsk_error_get());
+        RaiseError(EIOError, "Error opening File: %s", safe_tsk_error_get());
         tsk_error_reset();
         return NULL;
     }
@@ -702,7 +759,24 @@ static TSK_FS_ATTR_RUN *Attribute_iternext(Attribute self) {
     if(self->current == self->info->nrd.run) {
         self->current = NULL;
     }
-    return (TSK_FS_ATTR_RUN *) talloc_memdup(NULL, result, sizeof(*result));
+    {
+        /* Parent the duplicated run on self so it does not leak if the
+         * caller drops the returned object without an explicit free; the
+         * NULL parent in the previous code made each iteration a
+         * standalone allocation that nothing else would ever reap.
+         */
+        TSK_FS_ATTR_RUN *dup = (TSK_FS_ATTR_RUN *) talloc_memdup(
+            self, result, sizeof(*result));
+        if(dup == NULL) {
+            /* Returning NULL from iternext without RaiseError would
+             * silently terminate iteration as if the run list ended.
+             * Set a clear error so the caller raises MemoryError.
+             */
+            RaiseError(ENoMemory,
+                       "Unable to duplicate attribute run.");
+        }
+        return dup;
+    }
 }
 
 VIRTUAL(Attribute, Object) {
@@ -749,7 +823,7 @@ static Volume_Info Volume_Info_Con(Volume_Info self, Img_Info img,
     self->info = tsk_vs_open((TSK_IMG_INFO *) img->img, offset, type);
 
     if(self->info == NULL) {
-        RaiseError(EIOError, "Error opening Volume_Info: %s", tsk_error_get());
+        RaiseError(EIOError, "Error opening Volume_Info: %s", safe_tsk_error_get());
         tsk_error_reset();
         return NULL;
     }


### PR DESCRIPTION
## Summary

Defensive sanity checks across the C extension and the wrapper code generator, with a new regression-test module that pins each fix. No threading or free-threading work in this PR — completely independent of the work being done in #120.

This is PR 2 of like 5 PRs that split of the work currently on the `freethreading-compat-fixes` branch / PR #120.

## Changes

### `tsk3.cpp`

- **`safe_tsk_error_get()` helper** wrapping `tsk_error_get()` so a NULL from libtsk (EOF / bounds paths that return -1 without setting `t_errno`) does not get passed straight into a `%s` format. Applied at every `RaiseError(..., "%s", tsk_error_get())` site.
- **`Img_Info_dest`**: guard `tsk_img_close` and the `cache_lock` teardown with `if(self->img != NULL)` so destruction of a half-built `Img_Info` does not segfault.
- **`Img_Info_Con`**: install `talloc_set_destructor` before the allocations, so any error return from `tsk_img_open` / `talloc_zero` does not leak the partial libtsk state.
- **`IMG_INFO_read`** (libtsk-side callback): check the pytsk error slot after dispatching into a proxied subclass `read()` and return `-1` to libtsk on Python error. Previously a Python exception in the override was invisible to libtsk, which would consume garbage / short data.
- **`FS_Info_open` / `FS_Info_open_meta` / `Directory_next`**: explicit `RaiseError(ENoMemory, ...)` when `CONSTRUCT_CREATE` returns NULL. Previously a NULL allocation silently returned NULL to the Python wrapper without setting an exception, which surfaces as `SystemError: returned NULL without setting an exception` instead of a clean `MemoryError`.
- **`FS_Info_exit`**: replace `exit(0)` with `RaiseError(ERuntimeError, ...)`. The previous code let any Python caller of `FS_Info.exit()` terminate the host interpreter — a trivial DoS for any process that loads pytsk3 alongside untrusted user code (notebooks, plugins, batch runners).
- **`Attribute_iternext`**: parent the duplicated `TSK_FS_ATTR_RUN` on `self` instead of `NULL` so it doesn't leak; raise `ENoMemory` on dup failure so iteration fails loudly rather than terminating as if the run list ended.

### `class_parser.py`

Hardens the generated wrapper code so its NULL / bounds / error paths fail safely. Highlights:

- **`ProxiedImg_Info_read`** clamps `tmp_len` from the Python `read()` return to the libtsk-requested length before `memcpy`. Without the clamp, a subclass that returned more bytes than libtsk asked for overflowed libtsk's heap cache slot.
- **Generated struct accessors** refuse to dereference an unbound `info` pointer; raise `RuntimeError` instead of crashing.
- **Error fetch** handles `exception_value == NULL` (e.g. `PyErr_SetNone(KeyboardInterrupt)`) by emitting a placeholder message instead of `%s`-ing a NULL.
- **Generated iterator dispatch**: NULL checks on `py_method`, `item_object`, and `dict` before use.

### `tests/security.py`

Four regression tests that pin each behavior change:

- `HeapOverflowOnProxiedReadTest` — subclass returns 4x the requested bytes; verifies the codegen clamp.
- `ExitMethodDoesNotKillInterpreterTest` — `FS_Info.exit()` raises `RuntimeError`, does not call `exit()`.
- `StructWrapperUninitializedAccessTest` — accessing fields on an unbound wrapper raises `RuntimeError`, not segfault.
- `ErrorMessageWithoutLibtskErrnoTest` — error messages are well-formed when libtsk didn't set a `t_errno`.

## Relationship to PR #120

This PR carves out the security-only commits from `freethreading-compat-fixes` so they can be reviewed and landed independently of the larger free-threading work.